### PR TITLE
skip-slug on getting started

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -19,6 +19,7 @@ navigation:
   - tab: documentation
     layout:
       - section: Getting Started
+        skip-slug: true
         contents:
           - page: What is Tesseral?
             path: ./pages/what-is-tesseral.md


### PR DESCRIPTION
That way it's `/docs/quickstart`