### PR TITLE
Fix gtag script

### DIFF
--- a/fern/custom.js
+++ b/fern/custom.js
@@ -6,7 +6,7 @@ clearbit.setAttribute("referrerPolicy", "strict-origin-when-cross-origin");
 document.head.appendChild(clearbit);
 
 // Google Tag Manager stuffs
-var gtm = document.createElement1("script");
+var gtm = document.createElement("script");
 gtm.src = "https://www.googletagmanager.com/gtm.js?id=G-HW27FX565S";
 gtm.setAttribute("async", "true");
 document.head.appendChild(gtm);


### PR DESCRIPTION
Not sure what happened here.. typo?

The clearbit script also throws an error. Should probably update or remove that too.

<img width="1840" alt="Screenshot 2025-06-30 at 7 50 01 PM" src="https://github.com/user-attachments/assets/a67529d5-a055-4f93-b1ef-89b5e36ee084" />
