### PR TITLE
Fix C# namespace

### DIFF
--- a/fern/apis/backend/generators.yml
+++ b/fern/apis/backend/generators.yml
@@ -62,5 +62,5 @@ groups:
           mode: pull-request
         smart-casing: true
         config:
-          namespace: Tesseral.Client
-          client-class-name: Tesseral
+          namespace: Tesseral.Api
+          client-class-name: Client


### PR DESCRIPTION
To avoid conflict between root namespace and client type name